### PR TITLE
Remove the duplicate, immediate check for $(window).scrollTop() > 100…

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -35,9 +35,10 @@
     }
   });
 
-  if ($(window).scrollTop() > 100) {
-    $('#header').addClass('header-scrolled');
-  }
+  // Might be redundant
+  // if ($(window).scrollTop() > 100) {
+  //   $('#header').addClass('header-scrolled');
+  // }
 
   // Smooth scroll for the navigation and links with .scrollto classes
   $('.main-nav a, .mobile-nav a, .scrollto').on('click', function() {


### PR DESCRIPTION
… that exists outside the main scroll function.

The logic inside the $(window).scroll() handler is sufficient to handle the class addition/removal dynamically. The extra check only runs once at page load and is unnecessary overhead.